### PR TITLE
rename OMNet.cmake

### DIFF
--- a/OMNet.cmake
+++ b/OMNet.cmake
@@ -1,6 +1,0 @@
-# Import the OMNet++ CMake modules
-include(ImportOppTarget)
-include(GenerateOppMessage)
-include(GetNedFolders)
-include(AddOppBuildTarget)
-include(AddOppRun)

--- a/OmnetppHelpers.cmake
+++ b/OmnetppHelpers.cmake
@@ -1,0 +1,6 @@
+# Import the OMNeT++ CMake modules
+include(AddOppBuildTarget)
+include(AddOppRun)
+include(GenerateOppMessage)
+include(GetNedFolders)
+include(ImportOppTarget)


### PR DESCRIPTION
I think the file name *OMNet.cmake* is unfortunate with its lowercase *t*. My proposal is *OppHelpers.cmake* because CMake itself ships modules ending with *\*Helpers.cmake*. Other suggestions are welcome.

Besides the naming, I have reordered the included files alphabetically.